### PR TITLE
Upgrade to v5.1.55

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Scratch"
 description.en = "Programming language to create your own interactive stories, games, and animations"
 description.fr = "Langage de programmation pour créer vos propres histoires, jeux et animations interactifs"
 
-version = "5.1.53~ynh1"
+version = "5.1.54~ynh1"
 
 maintainers = []
 
@@ -45,8 +45,8 @@ ram.runtime = "50M"
 
 [resources]
     [resources.sources.main]
-    url = "https://github.com/scratchfoundation/scratch-gui/archive/refs/tags/v5.1.53.tar.gz"
-    sha256 = "47543ad4d3e6c7b8f48e3f3a4dd5d4b4daf7ab9a2cc42df4ef1dd7a3111e1702"
+    url = "https://github.com/scratchfoundation/scratch-gui/archive/refs/tags/v5.1.54.tar.gz"
+    sha256 = "fee18c92f8ae9070c4188e1065908273bb398e80195a70b41de4322532c3d65a"
     autoupdate.strategy = "latest_github_tag"
 
     [resources.system_user]

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Scratch"
 description.en = "Programming language to create your own interactive stories, games, and animations"
 description.fr = "Langage de programmation pour créer vos propres histoires, jeux et animations interactifs"
 
-version = "5.1.54~ynh1"
+version = "5.1.55~ynh1"
 
 maintainers = []
 
@@ -45,8 +45,8 @@ ram.runtime = "50M"
 
 [resources]
     [resources.sources.main]
-    url = "https://github.com/scratchfoundation/scratch-gui/archive/refs/tags/v5.1.54.tar.gz"
-    sha256 = "fee18c92f8ae9070c4188e1065908273bb398e80195a70b41de4322532c3d65a"
+    url = "https://github.com/scratchfoundation/scratch-gui/archive/refs/tags/v5.1.55.tar.gz"
+    sha256 = "b4c63955747272d7a5bebe9e0c21818cd00e736cc038911b28451570a7ac8aec"
     autoupdate.strategy = "latest_github_tag"
 
     [resources.system_user]


### PR DESCRIPTION
Upgrade sources
- `main` v5.1.55: https://github.com/scratchfoundation/scratch-gui/releases/tag/5.1.55

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
